### PR TITLE
Update to the same GO1.13 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=golang:1.13.0-buster
+ARG BASE_IMAGE=golang:1.13.4-buster
 ARG GOMOCK_VERSION=v1.3.1
 
 FROM ${BASE_IMAGE}


### PR DESCRIPTION
Should be tagged as `1.13.4-1.3.1`